### PR TITLE
Add old events and update Meetup information sidebar

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,7 +1,7 @@
-### Croatia Information
-* Provide Group Information
+<!-- ### Croatia Information
+* Provide Group Information -->
 
 ### Social Links
-* [Meetup](https://www.meetup.com/OWASP-Croatia-Meetup-Group/)
+* [OWASP Croatia Meetup Group](https://www.meetup.com/OWASP-Croatia-Meetup-Group/)
 
 

--- a/tab_oldevents.md
+++ b/tab_oldevents.md
@@ -21,6 +21,15 @@ Speaker name and about.
 </blockquote> -->
 
 ## Past Events
-<br/> <br/>
-
-
+<!-- <br/> <br/> -->
+-  27th of February 2019 at [Cloud Native meetup - Kino Europa](https://www.meetup.com/Kubernetes-Croatia/events/258931456/)
+- At the DORS/CLUC 2019 (Zagreb) 18.04.2019 - https://2019.dorscluc.org/
+- At [BSidesVarazdin](https://bsidesvarazdin.org) - 18.9.2019
+- At Kubernetes and Cloud Native meetup Zagreb 5.12.2019 - https://www.meetup.com/Kubernetes-Croatia/events/266384582/
+- OWASP meetup at the IoT Hacking School of 2018 | ([Info](https://hack.foi.hr))
+- OWASP meetup at the FSec 2017 ([Photos](https://www.flickr.com/photos/58943051@N07/sets/72157667605653398)) | ([Info](https://fsec.foi.hr))
+- OWASP meetup at FSec 2016 ([Photos](https://www.flickr.com/photos/58943051@N07/sets/72157673516643570)) | ([Info](https://fsec.foi.hr))
+- [OWASP application security summer school](http://www.foi.unizg.hr/Ljetna-skola-aplikacijske-sigurnost-na-FOI-ju) from 23th to 26th of September, 2014 @ FOI ([Photos](https://www.flickr.com/photos/58943051@N07/sets/72157648047647530/))
+- OWASP round table/meetup on 14.9.2015 @ [FOI/FSEC](http://fsec.foi.hr/)
+- OWASP regular meeting on 26.2.2016 at 18:00 (FOI Infoclub, Basement) | [Link to FB Event](https://www.facebook.com/events/1840212762872033/) | [Link to Web](http://www.foi.unizg.hr/hr/novosti/razmjena-vjestina-owasp-croatia-meetup)
+- OWASP Croatia meeting 11.5.2016 at 17:00 (FER Zagreb, Hall B2) | [Link to FB Event](https://www.facebook.com/events/475076512695702/) | [Event details](http://lists.owasp.org/pipermail/owasp-croatia/2016-May/000013.html) | [Email CFP](http://lists.owasp.org/pipermail/owasp-croatia/2016-April/000012.html)


### PR DESCRIPTION
Add old event information from the OWASP Wiki, update the Meetup information, hide placeholders.